### PR TITLE
Preserve partial output on timeout

### DIFF
--- a/server.py
+++ b/server.py
@@ -109,8 +109,9 @@ class JuliaSession:
         self.process.stdin.write(payload.encode())
         await self.process.stdin.drain()
 
+        lines: list[str] = []
+
         async def read_until_sentinel() -> str:
-            lines: list[str] = []
             while True:
                 raw = await self.process.stdout.readline()
                 if not raw:
@@ -134,10 +135,11 @@ class JuliaSession:
             except asyncio.TimeoutError:
                 self.process.kill()
                 await self.process.wait()
-                raise RuntimeError(
-                    f"Execution timed out after {timeout}s. "
-                    "Session killed; it will restart on next call."
-                )
+                partial = "\n".join(lines)
+                msg = f"Execution timed out after {timeout}s. Session killed; it will restart on next call."
+                if partial:
+                    msg += f"\n\nOutput before timeout:\n{partial}"
+                raise RuntimeError(msg)
         else:
             return await read_until_sentinel()
 


### PR DESCRIPTION
# Summary

When julia_eval times out, any stdout captured before the timeout is now included in the error message instead of being silently discarded. This is especially painful for long-running jobs, where you have some intermediate output, but then the job times out and you don't know how far the job actually got so you cannot debug which part took longer than the timeout.  

# MWE
If we execute the code
```julia
for i in 1:100
    println("iteration $i")
    sleep(1)
end
```
Before (with timeout=5):
```
Error: Execution timed out after 5.0s. Session killed; it will restart on next call.
```

After:
```
Error: Execution timed out after 5.0s. Session killed; it will restart on next call.
Output before timeout:
iteration 1
iteration 2
iteration 3
iteration 4
```

When there is no output before timeout (e.g. sleep(60)), the message is unchanged — no empty "Output before timeout" section is appended.

# Implementation

The lines accumulator in _execute_raw is hoisted out of the read_until_sentinel closure so it survives asyncio.wait_for() cancellation. The timeout handler then includes whatever was captured.