### PR TITLE
feat: write large outputs to file instead of returning inline

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import hashlib
 import os
 import re
 import shutil
@@ -17,6 +18,8 @@ DEFAULT_TIMEOUT = 60.0
 DEFAULT_JULIA_ARGS = ("--startup-file=no", "--threads=auto")
 PKG_PATTERN = re.compile(r"\bPkg\.")
 TEMP_SESSION_KEY = "__temp__"
+OUTPUT_THRESHOLD = 5000  # chars; outputs larger than this are written to a file
+OUTPUT_PREVIEW = 500  # chars of preview shown inline when output is written to a file
 
 mcp = FastMCP("julia")
 
@@ -185,6 +188,19 @@ class SessionManager:
             self._log_files[key] = open(path, "a")
         return self._log_files[key]
 
+    def write_large_output(self, output: str) -> str:
+        """Write output to a content-hashed file and return the path.
+
+        Using a content hash means multiple concurrent LLM instances writing
+        identical output converge to the same filename.
+        """
+        h = hashlib.sha256(output.encode()).hexdigest()[:16]
+        path = os.path.join(self._log_dir, f"output_{h}.txt")
+        if not os.path.exists(path):
+            with open(path, "w") as f:
+                f.write(output)
+        return path
+
     def _cleanup_logs(self) -> None:
         for f in self._log_files.values():
             try:
@@ -281,6 +297,10 @@ async def julia_eval(
     Persistent REPL session with state preserved between calls.
     Each env_path gets its own session, started lazily.
 
+    Large outputs (over 5000 chars) are written to a file. The tool returns the
+    file path and a short preview. Use Bash/Grep/Read on that file to inspect
+    the full output without loading it all into context.
+
     Args:
         code: Julia code to evaluate. Use display(...)/println(...) to see output.
         env_path: Julia project directory path. Omit for a temporary environment.
@@ -296,7 +316,16 @@ async def julia_eval(
     try:
         session = await manager.get_or_create(env_path)
         output = await session.execute(code, timeout=effective_timeout)
-        return output if output else "(no output)"
+        if not output:
+            return "(no output)"
+        if len(output) > OUTPUT_THRESHOLD:
+            path = manager.write_large_output(output)
+            preview = output[:OUTPUT_PREVIEW]
+            return (
+                f"[Output too large ({len(output):,} chars). Full output written to {path}]\n"
+                f"\nFirst {OUTPUT_PREVIEW} chars:\n{preview}"
+            )
+        return output
     except RuntimeError as e:
         # Clean up dead session so next call starts fresh
         key = manager._key(env_path)

--- a/test_server.py
+++ b/test_server.py
@@ -11,7 +11,9 @@ import pytest_asyncio
 from mcp.shared.memory import create_connected_server_and_client_session
 
 import server as server_mod
-from server import JuliaSession, SessionManager, TEMP_SESSION_KEY
+import hashlib
+
+from server import JuliaSession, SessionManager, TEMP_SESSION_KEY, OUTPUT_THRESHOLD, OUTPUT_PREVIEW
 
 
 # -- Helpers --
@@ -552,3 +554,66 @@ class TestMCPTools:
             text = result.content[0].text
             assert "timed out" in text
             assert "Output before timeout" not in text
+
+    async def test_large_output_written_to_file(self):
+        """Output exceeding OUTPUT_THRESHOLD is written to a file, not returned inline."""
+        async with mcp_client_session() as client:
+            n = OUTPUT_THRESHOLD + 1
+            result = await client.call_tool(
+                "julia_eval", {"code": f'print("x"^{n})'}
+            )
+            text = result.content[0].text
+            assert "Output too large" in text
+            assert f"{n:,} chars" in text
+            # Extract file path from the message and verify the file exists with full output
+            path_line = [l for l in text.splitlines() if "output_" in l][0]
+            path = path_line.split("written to ")[-1].rstrip("]")
+            assert os.path.isfile(path)
+            assert open(path).read() == "x" * n
+
+    async def test_large_output_preview_shown(self):
+        """The first OUTPUT_PREVIEW chars are shown inline."""
+        async with mcp_client_session() as client:
+            n = OUTPUT_THRESHOLD + 1
+            result = await client.call_tool(
+                "julia_eval", {"code": f'print("y"^{n})'}
+            )
+            text = result.content[0].text
+            assert "y" * OUTPUT_PREVIEW in text
+
+    async def test_small_output_returned_inline(self):
+        """Output at or below the threshold is returned inline as before."""
+        async with mcp_client_session() as client:
+            result = await client.call_tool(
+                "julia_eval", {"code": f'print("z"^{OUTPUT_THRESHOLD})'}
+            )
+            text = result.content[0].text
+            assert text == "z" * OUTPUT_THRESHOLD
+
+    async def test_large_output_same_content_same_file(self):
+        """Identical outputs map to the same file (deduplication)."""
+        async with mcp_client_session() as client:
+            n = OUTPUT_THRESHOLD + 1
+            paths = []
+            for _ in range(2):
+                result = await client.call_tool(
+                    "julia_eval", {"code": f'print("d"^{n})'}
+                )
+                text = result.content[0].text
+                path_line = [l for l in text.splitlines() if "output_" in l][0]
+                paths.append(path_line.split("written to ")[-1].rstrip("]"))
+            assert paths[0] == paths[1]
+
+    async def test_large_output_different_content_different_file(self):
+        """Different outputs map to different files."""
+        async with mcp_client_session() as client:
+            n = OUTPUT_THRESHOLD + 1
+            paths = []
+            for ch in ("e", "f"):
+                result = await client.call_tool(
+                    "julia_eval", {"code": f'print("{ch}"^{n})'}
+                )
+                text = result.content[0].text
+                path_line = [l for l in text.splitlines() if "output_" in l][0]
+                paths.append(path_line.split("written to ")[-1].rstrip("]"))
+            assert paths[0] != paths[1]


### PR DESCRIPTION
Large julia_eval outputs are expensive: every character returned by the tool enters the LLM context and stays there for the rest of the session.

This PR caps inline output at 5000 chars. When output exceeds that, the full content is written to a content-hashed file and the tool returns the file path plus a 500-char preview:

```
[Output too large (45,231 chars). Full output written to /tmp/julia-mcp-logs-abc/output_3f7a2b1c4e8d9f0a.txt]

First 500 chars:
...
```

The LLM can then use Grep/Read/Bash on that path to inspect only what it needs, without pulling everything into context. Content-hashing the filename means identical outputs deduplicate naturally and concurrent instances never conflict.