### PR TITLE
Fix julia_restart silently no-op'ing on missing env_path

### DIFF
--- a/server.py
+++ b/server.py
@@ -267,11 +267,14 @@ class SessionManager:
             self._sessions[key] = session
             return session
 
-    async def restart(self, env_path: str | None) -> None:
+    async def restart(self, env_path: str | None) -> bool:
+        """Kill the session for `env_path`, returning True if one was found."""
         key = self._key(env_path)
         if key in self._sessions:
             await self._sessions[key].kill()
             del self._sessions[key]
+            return True
+        return False
 
     def list_sessions(self) -> list[dict]:
         result = []
@@ -346,10 +349,21 @@ async def julia_restart(env_path: str | None = None) -> str:
     Do NOT restart just because source files were edited between script or test runs — Revise picks up those changes automatically.
 
     Args:
-        env_path: Environment to restart. If omitted, restarts the temporary session.
+        env_path: Environment to restart. If omitted, restarts the temporary session
+            (NOT every active session) — most callers should pass the same env_path
+            they used in julia_eval.
     """
-    await manager.restart(env_path)
-    return "Session restarted. A fresh session will start on next julia_eval call."
+    label = env_path if env_path is not None else "temporary"
+    killed = await manager.restart(env_path)
+    if killed:
+        return f"Session restarted (env_path={label}). A fresh session will start on next julia_eval call."
+    active = [s["env_path"] for s in manager.list_sessions()]
+    if active:
+        return (
+            f"No active session for env_path={label} — nothing to restart. "
+            f"Active sessions: {active}"
+        )
+    return f"No active session for env_path={label} — nothing to restart."
 
 
 @mcp.tool()

--- a/test_server.py
+++ b/test_server.py
@@ -238,7 +238,8 @@ class TestSessionManager:
     async def test_restart(self, manager: SessionManager):
         s1 = await manager.get_or_create(None)
         await s1.execute("x = 42", timeout=30.0)
-        await manager.restart(None)
+        killed = await manager.restart(None)
+        assert killed is True
         assert len(manager.list_sessions()) == 0
 
         s2 = await manager.get_or_create(None)
@@ -247,6 +248,29 @@ class TestSessionManager:
             "try; x; catch e; println(e); end", timeout=30.0
         )
         assert "UndefVarError" in result
+
+    async def test_restart_returns_false_when_no_session(self, manager: SessionManager):
+        killed = await manager.restart(None)
+        assert killed is False
+
+    async def test_restart_wrong_env_path_leaves_session_alive(self, manager: SessionManager):
+        tmpdir1 = os.path.realpath(tempfile.mkdtemp(prefix="julia-mcp-test-"))
+        tmpdir2 = os.path.realpath(tempfile.mkdtemp(prefix="julia-mcp-test-"))
+        try:
+            s1 = await manager.get_or_create(tmpdir1)
+            # Restart targeting the wrong path — should be a no-op
+            killed = await manager.restart(tmpdir2)
+            assert killed is False
+            assert s1.is_alive()
+            assert len(manager.list_sessions()) == 1
+            # Restart targeting the right path
+            killed = await manager.restart(tmpdir1)
+            assert killed is True
+            assert not s1.is_alive()
+        finally:
+            await manager.shutdown()
+            os.rmdir(tmpdir1)
+            os.rmdir(tmpdir2)
 
     async def test_list_sessions(self, manager: SessionManager):
         await manager.get_or_create(None)
@@ -545,7 +569,9 @@ class TestMCPTools:
     async def test_restart(self):
         async with mcp_client_session() as client:
             await client.call_tool("julia_eval", {"code": "x = 99"})
-            await client.call_tool("julia_restart", {})
+            result = await client.call_tool("julia_restart", {})
+            assert "restarted" in result.content[0].text.lower()
+            assert "temporary" in result.content[0].text
 
             result = await client.call_tool("julia_list_sessions", {})
             assert "No active" in result.content[0].text
@@ -554,6 +580,46 @@ class TestMCPTools:
                 "julia_eval", {"code": "try; x; catch e; println(e); end"}
             )
             assert "UndefVarError" in result.content[0].text
+
+    async def test_restart_reports_no_session_found(self):
+        async with mcp_client_session() as client:
+            # No sessions yet; the temp restart should report nothing was found
+            result = await client.call_tool("julia_restart", {})
+            text = result.content[0].text
+            assert "No active session" in text
+            assert "temporary" in text
+
+    async def test_restart_lists_active_sessions_when_target_missing(self):
+        async with mcp_client_session() as client:
+            tmpdir1 = os.path.realpath(tempfile.mkdtemp(prefix="julia-mcp-test-"))
+            tmpdir2 = os.path.realpath(tempfile.mkdtemp(prefix="julia-mcp-test-"))
+            try:
+                # Create a session for tmpdir1, then try to restart tmpdir2
+                await client.call_tool("julia_eval", {"code": "1", "env_path": tmpdir1})
+                result = await client.call_tool(
+                    "julia_restart", {"env_path": tmpdir2}
+                )
+                text = result.content[0].text
+                assert "No active session" in text
+                assert tmpdir2 in text  # reports the requested env_path
+                assert tmpdir1 in text  # lists the actually-active session
+            finally:
+                os.rmdir(tmpdir1)
+                os.rmdir(tmpdir2)
+
+    async def test_restart_with_env_path_reports_that_path(self):
+        async with mcp_client_session() as client:
+            tmpdir = os.path.realpath(tempfile.mkdtemp(prefix="julia-mcp-test-"))
+            try:
+                await client.call_tool("julia_eval", {"code": "1", "env_path": tmpdir})
+                result = await client.call_tool(
+                    "julia_restart", {"env_path": tmpdir}
+                )
+                text = result.content[0].text
+                assert "restarted" in text.lower()
+                assert tmpdir in text
+            finally:
+                os.rmdir(tmpdir)
 
     async def test_eval_cwd_regular(self):
         async with mcp_client_session() as client:


### PR DESCRIPTION
`SessionManager.restart` now returns a `bool` indicating whether a session was actually killed; `julia_restart` surfaces this and reports the `env_path` involved, plus the list of active sessions when the requested one doesn't exist. Previously it returned "Session restarted" unconditionally — including when called with no `env_path` (which targets only the temporary session) while the caller expected it to act on their named project session.

Docstring updated to flag that omitting `env_path` restarts only the temporary session, not every active session.

Tests added at both the SessionManager and MCP-tool layers, including one that directly proves a session with a different `env_path` is left alive.