### PR TITLE
Restrict mcp dependency version to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "MCP server for running Julia code in persistent REPL sessions"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.0",
+    "mcp>=1.0,<2.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fixes #23 by disallowing v2.0 of mcp. Can be reverted in the future if the package is updated to work with mcp v2.0.